### PR TITLE
refactor(ocm): Streamline OCM component name and repository branding

### DIFF
--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,4 +1,4 @@
-name: ocm.software/ocm-gear/prometheus
+name: ocm.software/open-delivery-gear/observability
 resources:
   - name: prometheus-operator
     version: v0.89.0

--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@
 
 [![REUSE status](https://api.reuse.software/badge/github.com/open-component-model/odg-observability)](https://api.reuse.software/info/github.com/open-component-model/odg-observability)
 
+![tests](https://github.com/open-component-model/odg-observability/actions/workflows/non-release.yaml/badge.svg)
+![release](https://github.com/open-component-model/odg-observability/actions/workflows/release.yaml/badge.svg)
+
 This repository is used to model the `ocm.software/open-delivery-gear/observability` component, which contains
 a resource referencing the Helm chart used to deploy the prometheus logging stack of the Open Delivery Gear.

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 [![REUSE status](https://api.reuse.software/badge/github.com/open-component-model/prometheus)](https://api.reuse.software/info/github.com/open-component-model/prometheus)
 
-This repository is used to model the `ocm.software/ocm-gear/prometheus` component, which contains
-a resource referencing the Helm chart used to deploy the prometheus logging stack of the OCM-Gear.
+This repository is used to model the `ocm.software/open-delivery-gear/observability` component, which contains
+a resource referencing the Helm chart used to deploy the prometheus logging stack of the Open Delivery Gear.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prometheus
 
-[![REUSE status](https://api.reuse.software/badge/github.com/open-component-model/prometheus)](https://api.reuse.software/info/github.com/open-component-model/prometheus)
+[![REUSE status](https://api.reuse.software/badge/github.com/open-component-model/odg-observability)](https://api.reuse.software/info/github.com/open-component-model/odg-observability)
 
 This repository is used to model the `ocm.software/open-delivery-gear/observability` component, which contains
 a resource referencing the Helm chart used to deploy the prometheus logging stack of the Open Delivery Gear.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,10 +1,10 @@
 version = 1
-SPDX-PackageName = "OCM Prometheus"
-SPDX-PackageSupplier = "Jonas Brand <j.brand@sap.com>"
-SPDX-PackageDownloadLocation = "https://github.com/open-component-model/prometheus"
+SPDX-PackageName = "odg-observability"
+SPDX-PackageSupplier = "ospo@sap.com"
+SPDX-PackageDownloadLocation = "https://github.com/open-component-model/odg-observability"
 
 [[annotations]]
 path = "**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = ["2024 SAP SE or an SAP affiliate company and Open Component Model contributors \\", "<j.brand@sap.com>"]
+SPDX-FileCopyrightText = "2025 SAP SE or an SAP affiliate company and Open Component Model contributors"
 SPDX-License-Identifier = "Apache-2.0"

--- a/extension-definitions.yaml
+++ b/extension-definitions.yaml
@@ -2,7 +2,7 @@ name: prometheus-operator
 installation:
   ocm_references:
     - helm_chart_name: prometheus-operator
-      name: ocm.software/ocm-gear/prometheus
+      name: ocm.software/open-delivery-gear/observability
       version: 0.29.0-dev
       artefact:
         name: prometheus-operator

--- a/extension-definitions.yaml
+++ b/extension-definitions.yaml
@@ -16,9 +16,5 @@ installation:
       helm_attribute: host
       value: prometheus.${base_url}
       value_type: python-string-template
-    - helm_chart_name: prometheus-operator
-      helm_attribute: rbac.annotations."resources.gardener.cloud/keep-object"
-      value: '"${keep_clusterwide_objects}"'
-      value_type: python-string-template
 outputs: []
 dependencies: []


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/open-component-model/open-delivery-gear/issues/94

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```breaking operator
The `ocm.software/ocm-gear/prometheus` has been renamed to `ocm.software/open-delivery-gear/observability`
```
